### PR TITLE
Fix bug with linedefs having same sidedef on both sides

### DIFF
--- a/nodebuild_extract.cpp
+++ b/nodebuild_extract.cpp
@@ -521,8 +521,6 @@ int FNodeBuilder::StripMinisegs (TArray<MapSegEx> &segs, int subsector, short bb
 				newseg.side = ld->sidenum[1] == org->sidedef ? 1 : 0;
 			}
 
-
-			newseg.side = Level.Lines[org->linedef].sidenum[1] == org->sidedef ? 1 : 0;
 			segs.Push (newseg);
 			++count;
 		}


### PR DESCRIPTION
Because of a forgotten line of code which wasn't deleted, extended segs get the wrong "side" information when a linedef has the same sidedef repeated on both parts of the 2-sided wall. The line was safe to delete because clearly the side was just set inside both branches of the if block.