### PR TITLE
add latest cmake to version requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.4 )
+cmake_minimum_required( VERSION 2.4...4.0.2 )
 if( COMMAND cmake_policy )
 	cmake_policy( SET CMP0003 NEW )
 endif( COMMAND cmake_policy )


### PR DESCRIPTION
this prevents current versions of cmake from erroring out due to out-of-date version requirements. we could have just changed the minimum to 3.5, but that results in a further deprecation warning; instead, adding the max gives the most amount of time until someone needs to update this again, and as a bonus should remain compatible with older cmake versions. in theory at least, we're not a cmake guru